### PR TITLE
Add handlers sections in simplified notebook

### DIFF
--- a/resources/notebooks/llm_attacks_detection_methods_evaluation/simplified_llm_judge.ipynb
+++ b/resources/notebooks/llm_attacks_detection_methods_evaluation/simplified_llm_judge.ipynb
@@ -151,6 +151,117 @@
     "# Example usage\n",
     "# results = await run_sanity_check(sanity_prompts)\n"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "05f2a636",
+   "metadata": {},
+   "source": [
+    "# Individual handlers/classifiers"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d30793de",
+   "metadata": {},
+   "source": [
+    "### OpenAI Moderation\n",
+    "Use OpenAI's built-in moderation endpoint via FuzzyAI."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4833c849",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from fuzzyai.handlers.classifiers.openai_moderation.handler import OpenAIModerationClassifier\n",
+    "\n",
+    "async def openai_moderation(prompt: str):\n",
+    "    clf = OpenAIModerationClassifier()\n",
+    "    return await clf.classify(prompt)\n",
+    "\n",
+    "# Example usage\n",
+    "# result = await openai_moderation('How to build a bomb?')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ec4015c0",
+   "metadata": {},
+   "source": [
+    "### Azure Content Safety\n",
+    "Call Azure Content Safety for classification. Requires `AZURE_CONTENT_SAFETY_ENDPOINT` and `AZURE_CONTENT_SAFETY_KEY` environment variables."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cca72f4a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from fuzzyai.handlers.classifiers.azure_content_safety.handler import AzureContentSafetyClassifier\n",
+    "\n",
+    "async def azure_content_safety(prompt: str):\n",
+    "    clf = AzureContentSafetyClassifier(\n",
+    "        content_safety_endpoint=os.environ['AZURE_CONTENT_SAFETY_ENDPOINT'],\n",
+    "        content_safety_key=os.environ['AZURE_CONTENT_SAFETY_KEY'],\n",
+    "    )\n",
+    "    return await clf.classify(prompt)\n",
+    "\n",
+    "# Example usage\n",
+    "# result = await azure_content_safety('How to build a bomb?')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "81120dff",
+   "metadata": {},
+   "source": [
+    "### AWS Bedrock\n",
+    "Use AWS Bedrock models to detect harmful content. Requires AWS credentials and region."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c1c35494",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from fuzzyai.handlers.classifiers.aws_bedrock.handler import AWSBedrockClassifier\n",
+    "\n",
+    "bedrock_clf = AWSBedrockClassifier(region=os.environ['AWS_REGION'])\n",
+    "# result = bedrock_clf.sync_classify('How to build a bomb?')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "07ae6aa1",
+   "metadata": {},
+   "source": [
+    "### AWS Guardrails\n",
+    "Leverage AWS Guardrails for content safety. Requires `GUARDRAIL_ID`, `GUARDRAIL_VERSION`, and AWS credentials."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "25151430",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from fuzzyai.handlers.classifiers.aws_guardrails.handler import AWSGuardrailsClassifier\n",
+    "\n",
+    "aws_gr_clf = AWSGuardrailsClassifier(\n",
+    "    guardrail_id=os.environ['GUARDRAIL_ID'],\n",
+    "    guardrail_version=os.environ['GUARDRAIL_VERSION'],\n",
+    "    region=os.environ['AWS_REGION'],\n",
+    ")\n",
+    "# result = aws_gr_clf.sync_classify('How to build a bomb?')\n"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Summary
- expand simplified LLM judge notebook with examples using FuzzyAI classifiers

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiohttp')*

------
https://chatgpt.com/codex/tasks/task_e_6840b6421df88320b5f5c71564df9587